### PR TITLE
fix: Improve font handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ This is the source code that powers [evadecker.com](https://evadecker.com). It's
 
 **Fonts**
 
-- Nimbus Sans by URW Type Foundary via [Adobe Fonts](https://fonts.adobe.com/fonts/nimbus-sans)
+- Nimbus Sans and Nimbus Sans Extended by URW Type Foundary via [Adobe Fonts](https://fonts.adobe.com/fonts/nimbus-sans)
 - Minion 3 by Robert Slimbach via [Adobe Fonts](https://fonts.adobe.com/fonts/minion-3)
 - 04b by [Yuji Oshimoto](http://www.04.jp.org/)

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,7 +32,7 @@
   }
 
   footer a {
-    font-family: "nimbus-sans", sans-serif;
+    font-family: var(--font-sans);
     display: inline-block;
     color: var(--text);
   }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -38,7 +38,7 @@ import SamStickers from "./samwise/SamStickers";
   }
 
   .header p {
-    font-family: "nimbus-sans", sans-serif;
+    font-family: var(--font-sans);
     font-size: 1rem;
     line-height: 1.3;
     margin-top: 1em;

--- a/src/components/dialogue/dialogue.module.css
+++ b/src/components/dialogue/dialogue.module.css
@@ -51,7 +51,7 @@
 
 .evaText,
 .samText {
-  font-family: "nimbus-sans", sans-serif;
+  font-family: var(--font-sans);
 }
 
 .emote {

--- a/src/components/samwise/samstickers.module.css
+++ b/src/components/samwise/samstickers.module.css
@@ -24,7 +24,7 @@
   position: fixed;
   right: 24px;
   bottom: 24px;
-  font-family: "nimbus-sans", sans-serif;
+  font-family: var(--font-sans);
   font-weight: 700;
   cursor: pointer;
   pointer-events: auto;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,7 +40,8 @@ const { title, description } = Astro.props;
     />
     <script>
       // Asynchronously load Adobe Fonts
-      // Technique via https://www.filamentgroup.com/lab/load-css-simpler/
+      // https://www.jayfreestone.com/writing/avoiding-repeat-async-fout/
+
       const fontKey = "fontLoaded";
       const stylesheet = "https://use.typekit.net/qbm1slx.css";
       // Once the font has loaded:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,8 +33,32 @@ const { title, description } = Astro.props;
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
     <link rel="manifest" href="manifest.json" />
-    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
-    <link rel="stylesheet" href="https://use.typekit.net/qbm1slx.css" />
+    <link
+      rel="preconnect"
+      href="https://use.typekit.net/qbm1slx.css"
+      crossorigin
+    />
+    <script>
+      // Asynchronously load Adobe Fonts
+      // Technique via https://www.filamentgroup.com/lab/load-css-simpler/
+      const fontKey = "fontLoaded";
+      const stylesheet = "https://use.typekit.net/qbm1slx.css";
+      // Once the font has loaded:
+      // - Set the media type, thereby applying the CSS.
+      // - Store a boolean indicating we've already loaded the font.
+      function onFontLoad(script) {
+        script.media = "all";
+        sessionStorage.setItem(fontKey, "true");
+      }
+
+      // If we've loaded it once before, load the CSS in a blocking way.
+      // Otherwise, we load it asynchronously.
+      const styleTag = sessionStorage.getItem(fontKey)
+        ? `<link rel="stylesheet" href="${stylesheet}">`
+        : `<link rel="stylesheet" href="${stylesheet}" media="print" onload="onFontLoad(this)">`;
+
+      document.write(styleTag);
+    </script>
     <title>{title}</title>
   </head>
   <body>

--- a/src/styles/typography.module.css
+++ b/src/styles/typography.module.css
@@ -1,8 +1,14 @@
+:global(:root) {
+  --font-sans: nimbus-sans, sans-serif;
+  --font-serif: minion-3, serif;
+  --font-display: nimbus-sans-extended, sans-serif;
+}
+
 html,
 body {
   font-size: 20px;
   line-height: 1.4;
-  font-family: "minion-3", serif;
+  font-family: var(--font-serif);
   font-weight: 400;
   text-rendering: optimizeLegibility;
 }
@@ -23,6 +29,6 @@ body {
 
 h1 {
   font-size: clamp(1.3rem, 8vw, 2.6rem);
-  font-family: "nimbus-sans-extended", sans-serif;
+  font-family: var(--font-display);
   font-weight: 700;
 }


### PR DESCRIPTION
- Load Adobe Fonts stylesheets async
- Prefer flash of unstyled text before initial fonts have loaded
- Use CSS variables for font families