### PR TITLE
fix: Soften 404 RGB styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-dom": "^18.2.7",
         "@vercel/analytics": "^1.0.2",
         "astro": "^3.0.6",
+        "autoprefixer": "^10.4.15",
         "classnames": "^2.3.2",
         "framer-motion": "^10.16.1",
         "howler": "^2.2.3",
@@ -3388,6 +3389,42 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001520",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "dev": true,
@@ -6049,6 +6086,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/framer-motion": {
@@ -9697,6 +9746,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
@@ -10358,8 +10415,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.6",
@@ -16758,6 +16814,19 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "autoprefixer": {
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
+      "requires": {
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001520",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "dev": true
@@ -18591,6 +18660,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
+    },
+    "fraction.js": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg=="
     },
     "framer-motion": {
       "version": "10.16.1",
@@ -20940,6 +21014,11 @@
     "normalize-path": {
       "version": "3.0.0"
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
+    },
     "npm-run-path": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
@@ -21369,8 +21448,7 @@
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "prebuild-install": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^18.2.7",
     "@vercel/analytics": "^1.0.2",
     "astro": "^3.0.6",
+    "autoprefixer": "^10.4.15",
     "classnames": "^2.3.2",
     "framer-motion": "^10.16.1",
     "howler": "^2.2.3",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require("autoprefixer")],
+};

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -11,7 +11,7 @@ import { Layout } from "@layouts";
 
 <style lang="scss">
   .scanlines {
-    position: fixed;
+    position: absolute;
     inset: 0;
     overflow: hidden;
     pointer-events: none;
@@ -20,6 +20,7 @@ import { Layout } from "@layouts";
     background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAGCAYAAAD37n+BAAAALElEQVQYV2NkYGD4/x9IMAIxAxoDmzhIHfU0gCxFB9S1AacfsFmNJQzAoQIAH84j/OCkeYUAAAAASUVORK5CYII=");
     background-size: 12px 6px;
     mix-blend-mode: color-dodge;
+    opacity: 0.5;
 
     &::after {
       content: "";
@@ -32,16 +33,13 @@ import { Layout } from "@layouts";
   }
 
   .glitch-container {
-    display: flex;
     position: absolute;
+    inset: 0;
+    display: flex;
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    flex: 1;
-    height: 100%;
-    width: 100%;
     overflow: hidden;
-    inset: 0;
     z-index: -1;
     animation: flicker 20ms infinite;
   }
@@ -56,9 +54,10 @@ import { Layout } from "@layouts";
     pointer-events: none;
     user-select: none;
     text-shadow:
-      -1px -1px 1px rgb(0 0 255),
-      1px 1px 1px rgb(255 0 0);
-    filter: blur(1px);
+      -1.5px 0 0 rgb(0 0 255),
+      1.5px 0 0 rgb(255 0 0),
+      0 1.5px 0 rgb(0 255 0);
+    filter: blur(1.5px);
 
     @media screen and (width <= 600px) {
       writing-mode: vertical-rl;
@@ -72,10 +71,14 @@ import { Layout } from "@layouts";
       top: 0;
       left: -0.01em;
       text-shadow:
-        -1px -1px 3px rgb(0 0 255),
-        1px 1px 3px rgb(255 0 0),
-        6px 0 2px var(--bg);
+        -1.5px 0 0 rgb(0 0 255),
+        1.5px 0 0 rgb(255 0 0),
+        0 1.5px 0 rgb(0 255 0),
+        10px 0 2px var(--bg);
       animation: text-offset 8s linear infinite;
+
+      // Dark mode transition
+      transition: text-shadow 1s ease-in-out;
     }
   }
 


### PR DESCRIPTION
- High opacity for the RGB pattern led to unpredictable effects on different devices depending on pixel density
- Lowered opacity keeps results more consistent
- Add autoprefixer for vendor-specific CSS styling
- Add green to chromatic aberration effect and make shadow `.5px` larger
- Fixes #93 