### PR TITLE
fix: Add canonical URL, use correct `theme-color`, prevent horizontal scroll, format page titles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,10 +6,8 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://evadecker.com",
   integrations: [react(), mdx()],
-  redirects: {
-    // "/work": "/work/cityblock",
-  },
   output: "static",
   adapter: vercel({
     webAnalytics: {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,6 +10,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#1d0206",
+  "theme_color": "#181118",
   "background_color": "#ffffff"
 }

--- a/src/components/Footer/footer.css.ts
+++ b/src/components/Footer/footer.css.ts
@@ -31,7 +31,7 @@ export const linkCol = style({
   display: "flex",
   flexDirection: "column",
   alignItems: "flex-start",
-  width: "9em",
+  paddingRight: tokens.space[8],
 });
 
 export const link = style({

--- a/src/components/Header/ToggleTheme.tsx
+++ b/src/components/Header/ToggleTheme.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@components";
-import { theme } from "@styles/theme.css";
+import { plum, plumDark } from "@radix-ui/colors";
 import { useEffect, useRef, useState } from "react";
 
 import * as styles from "./toggle-theme.css";
@@ -52,7 +52,10 @@ export const ToggleTheme = () => {
     // Update meta theme
     const metaTheme = document.querySelector('meta[name="theme-color"]');
     if (metaTheme !== null)
-      metaTheme.setAttribute("content", theme.background.default);
+      metaTheme.setAttribute(
+        "content",
+        activeTheme === "dark" ? plumDark.plum1 : plum.plum1
+      );
 
     handleAnimation();
   }, [activeTheme]);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,3 +1,7 @@
+import classNames from "classnames";
+
+import * as styles from "./icon.css";
+
 // Icons sourced from https://remixicon.com
 type IconType =
   | "download"
@@ -101,7 +105,7 @@ export const Icon = ({ icon, variant, size, className }: IconProps) => {
       fill="currentColor"
       width={pxSize}
       height={pxSize}
-      className={className}
+      className={classNames(styles.icon, className)}
     >
       {pathData}
     </svg>

--- a/src/components/Icon/icon.css.ts
+++ b/src/components/Icon/icon.css.ts
@@ -1,0 +1,6 @@
+import { theme } from "@styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const icon = style({
+  flexShrink: 0,
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "@styles/reset.css";
 import "@styles/base.css";
 
 import { Footer, Header } from "@components";
+import { plum } from "@radix-ui/colors";
 
 interface Props {
   title: string;
@@ -10,24 +11,27 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Eva Decker`;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="dark light" />
-    <meta name="theme-color" content="#ffdcdc" />
+    <meta name="theme-color" content={plum.plum1} />
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
     <link rel="manifest" href="manifest.json" />
+    <link rel="canonical" href={canonicalURL} />
     <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <link rel="stylesheet" href="https://use.typekit.net/qbm1slx.css" />
-    <title>{title}</title>
+    <title>{pageTitle}</title>
     <script>
       window.va =
         window.va ||

--- a/src/layouts/prose.css.ts
+++ b/src/layouts/prose.css.ts
@@ -59,3 +59,7 @@ globalStyle(`${article} h2:first-child`, {
 globalStyle(`${article} * + p`, {
   marginTop: "1em",
 });
+
+globalStyle(`${article} code`, {
+  fontSize: "0.9em",
+});

--- a/src/pages/colophon.md
+++ b/src/pages/colophon.md
@@ -6,13 +6,15 @@ description: Colophon is a designer-y word for “credits”. This site is possi
 
 I designed and built this site myself. All the code is open source and available on [Github](https://github.com/evadecker/evadecker.com).
 
-## Technology
+## Technology and Tooling
 
-This site is built using [Astro](https://astro.build), a incredibly robust little web framework which takes anything you throw at it—React, Next.JS, vanilla JavaScript—and produces a performant website with as little JavaScript on the final page as possible. Astro handles the simpler, static views, but for more interactive components I use [React](https://react.dev) and [TypeScript](https://www.typescriptlang.org). End-to-end tests are written using [Playwright](https://playwright.dev).
+This site is built using [Astro](https://astro.build). Astro handles the content-heavy views (written in [MDX](https://mdxjs.com)), but for more interactive components I use [React](https://react.dev) and [TypeScript](https://www.typescriptlang.org).
 
 Code is edited using [VS Code](https://code.visualstudio.com) on a [MacBook Pro](https://www.apple.com/macbook-pro/). My terminal of choice is [Warp](https://www.warp.dev). My go-to coding font is [MonoLisa](https://www.monolisa.dev).
 
-The site is deployed and hosted with [Vercel](https://vercel.com/).
+End-to-end tests are written using [Playwright](https://playwright.dev), and I use [Polypane](https://polypane.app) to preview the site in multiple viewports, test accessibility, and toggle user preferences like `(prefers-color-scheme)` and `(prefers-reduced-motion)`.
+
+Hosting and automatic deployment is handled with [Vercel](https://vercel.com/).
 
 ## Typography
 


### PR DESCRIPTION
- Add Polypane mention to colophon
- Adds a generated canonical URL to every page
- Fixes footer causing horizontal scroll on small viewports
- Appends ` · Eva Decker` to page titles that are not the homepage
- Fixes #115 
- Fixes #114 