### PR TITLE
feat: Add typography inspiration, adjust font weights and sizing

### DIFF
--- a/src/layouts/prose.css.ts
+++ b/src/layouts/prose.css.ts
@@ -16,13 +16,12 @@ export const articleBody = style({
       paddingTop: tokens.space[9],
       paddingBottom: tokens.space[9],
       fontSize: tokens.fontSize.h3,
-      color: theme.text.inlineIcon,
     },
   },
 });
 
 export const header = style({
-  padding: `2em 0 6em`,
+  padding: `4rem 0`,
 });
 
 export const subtitle = style({
@@ -30,7 +29,7 @@ export const subtitle = style({
   fontFamily: tokens.fontFamily.sans,
   fontVariationSettings: `'wdth' ${tokens.fontWidth.normal}, 'wght' ${theme.fontWeight.medium}`,
   lineHeight: tokens.lineHeight.h4,
-  marginTop: "0.3em",
+  marginTop: "1rem",
 });
 
 globalStyle(`${articleBody} p, ${articleBody} ol, ${articleBody} ul`, {
@@ -50,7 +49,7 @@ globalStyle(`${article} a:hover`, {
 });
 
 globalStyle(
-  `${article} h1, ${article} h2, ${article} h3, ${article} h4, ${article} h5, ${article} h6`,
+  `${article} h2, ${article} h3, ${article} h4, ${article} h5, ${article} h6`,
   {
     scrollMarginTop: tokens.space[5],
     marginBottom: "1rem",
@@ -77,7 +76,7 @@ globalStyle(
 );
 
 globalStyle(`${article} h2`, {
-  marginTop: "2em",
+  marginTop: "4rem",
 });
 
 globalStyle(`${article} h2:first-child`, {

--- a/src/layouts/prose.css.ts
+++ b/src/layouts/prose.css.ts
@@ -127,8 +127,8 @@ globalStyle(`${articleBody} ol li::before`, {
 globalStyle(`${article} code`, {
   backgroundColor: theme.text.codeBg,
   borderRadius: tokens.radius[1],
+  fontVariationSettings: `'wght' ${theme.fontWeight.code}`,
   padding: "0.1rem 0.2rem",
-  border: `1px solid ${theme.border.subtle}`,
   fontSize: "0.8em",
 });
 

--- a/src/layouts/prose.css.ts
+++ b/src/layouts/prose.css.ts
@@ -28,13 +28,17 @@ export const header = style({
 export const subtitle = style({
   fontSize: tokens.fontSize.h4,
   fontFamily: tokens.fontFamily.sans,
-  fontVariationSettings: `'wdth' ${tokens.fontWidth.normal}, 'wght' ${theme.fontWeight.normal}`,
+  fontVariationSettings: `'wdth' ${tokens.fontWidth.normal}, 'wght' ${theme.fontWeight.medium}`,
   lineHeight: tokens.lineHeight.h4,
-  color: theme.text.subtle,
   marginTop: "0.3em",
 });
 
-globalStyle(`${article} p a`, {
+globalStyle(`${articleBody} p, ${articleBody} ol, ${articleBody} ul`, {
+  fontFamily: tokens.fontFamily.serif,
+  fontVariationSettings: `'wght' ${theme.fontWeight.prose}`,
+});
+
+globalStyle(`${articleBody} :not(h1, h2, h3, h4, h5, h6) a`, {
   boxShadow: `inset 0 -2px ${theme.text.linkUnderline}`,
 });
 
@@ -49,6 +53,7 @@ globalStyle(
   `${article} h1, ${article} h2, ${article} h3, ${article} h4, ${article} h5, ${article} h6`,
   {
     scrollMarginTop: tokens.space[5],
+    marginBottom: "1rem",
   }
 );
 
@@ -79,12 +84,52 @@ globalStyle(`${article} h2:first-child`, {
   marginTop: 0,
 });
 
-globalStyle(`${articleBody} * + p`, {
+globalStyle(`${article} p + p`, {
+  textIndent: "2rem",
+});
+
+globalStyle(`${articleBody} * + ul, ${articleBody} * + ol`, {
   marginTop: "1em",
 });
 
+globalStyle(`${articleBody} ul ul, ${articleBody} ol ol`, {
+  marginTop: "0",
+});
+
+globalStyle(`${articleBody} ul, ${articleBody} ol`, {
+  listStyleType: "none",
+  paddingLeft: "2.5rem",
+});
+
+globalStyle(`${articleBody} li`, {
+  position: "relative",
+});
+
+globalStyle(`${articleBody} li::before`, {
+  position: "absolute",
+  width: "2.5rem",
+  left: "-2.5rem",
+  color: theme.text.subtle,
+});
+
+globalStyle(`${articleBody} ul li::before`, {
+  content: "→",
+  fontSize: "1.3em",
+  lineHeight: "1.3",
+});
+
+globalStyle(`${articleBody} ol li::before`, {
+  fontFamily: tokens.fontFamily.sans,
+  content: "counter(list-item, decimal-leading-zero)",
+  fontVariantNumeric: "tabular-nums",
+});
+
 globalStyle(`${article} code`, {
-  fontSize: "0.85em",
+  backgroundColor: theme.text.codeBg,
+  borderRadius: tokens.radius[1],
+  padding: "0.1rem 0.2rem",
+  border: `1px solid ${theme.border.subtle}`,
+  fontSize: "0.8em",
 });
 
 globalStyle(`${article} abbr`, {

--- a/src/pages/colophon.md
+++ b/src/pages/colophon.md
@@ -35,7 +35,7 @@ Type inspiration can be found anywhere, from comic art and video games to bodega
 
 ## Styling
 
-I use [Radix Colors](https://www.radix-ui.com/colors) to apply palettes consistently, ensure accessibility, and seamlessly switch between light and dark mode. Icons are from [Remix Icon](https://remixicon.com). Styles are written using [vanilla-extract](https://vanilla-extract.style)—a fantastic little library which adds TypeScript's type safety to your theming and variables and then compiles down to static CSS. I don’t use a grid; [here’s why.](https://gridless.design)
+I use [Radix Colors](https://www.radix-ui.com/colors) to apply palettes consistently, ensure accessibility, and seamlessly switch between light and dark mode. Icons are from [Remix Icon](https://remixicon.com). Styles are written using [vanilla-extract](https://vanilla-extract.style)—a fantastic little library which adds TypeScript's type safety to your theming and variables and then compiles down to static CSS. I [don’t use a grid](https://gridless.design).
 
 ## Sounds
 

--- a/src/pages/colophon.md
+++ b/src/pages/colophon.md
@@ -26,7 +26,7 @@ Headings and components are set in [Roc Grotesk Variable](https://fonts.adobe.co
 
 Typography is scaled using a lot of math and a [fluid type scale](https://utopia.fyi/blog/designing-with-fluid-type-scales) by [Utopia](https://utopia.fyi/type/calculator/), meaning that font sizes will interpolate between mobile and desktop to optimize for the current browser width.
 
-Type inspiration lives everywhere—comic art, video games, bodegas—but I often return to a handful of resources:
+Type inspiration can be found anywhere, from comic art and video games to bodega window displays, but I often return to a handful of resources:
 
 - [*The Elements of Typographic Style*](https://bookshop.org/a/97627/9780881792126) by Robert Bringhurst
 - [Butterick’s Practical Typography](https://practicaltypography.com)

--- a/src/pages/colophon.md
+++ b/src/pages/colophon.md
@@ -8,7 +8,7 @@ description: Colophon is a designer-y word for “how it’s made”—here’s 
 
 I designed and built this site myself. It's a home to share things I'm exploring and things I've built. It's a place for me to learn in public.
 
-All code is open source and available on [Github](https://github.com/evadecker/evadecker.com). The first commit was December 5, 2018, but the earliest version of this site dates back to 2015, an era where I eschewed versioning and uploaded files manually via <abbr title="File Transfer Protocol">FTP</abbr>. 😱 I've grown a lot since then—the technology around me has grown, too.
+All code is open source and available on [Github](https://github.com/evadecker/evadecker.com). The first commit was December 5, 2018, but the earliest version of this site dates back to 2015, an era where I eschewed versioning and uploaded files manually via <abbr title="File Transfer Protocol">FTP</abbr>. I've grown a lot since then—and the technology around me has grown, too.
 
 ## Technology
 
@@ -26,9 +26,16 @@ Headings and components are set in [Roc Grotesk Variable](https://fonts.adobe.co
 
 Typography is scaled using a lot of math and a [fluid type scale](https://utopia.fyi/blog/designing-with-fluid-type-scales) by [Utopia](https://utopia.fyi/type/calculator/), meaning that font sizes will interpolate between mobile and desktop to optimize for the current browser width.
 
+Type inspiration lives everywhere—comic art, video games, bodegas—but I often return to a handful of resources:
+
+- *The Elements of Typographic Style* by Robert Bringhurst
+- [Butterick’s Practical Typography](https://practicaltypography.com)
+- Bethany Heck’s [Font Review Journal](https://fontreviewjournal.com)
+- [Fonts In Use](https://fontsinuse.com)
+
 ## Styling
 
-I use [Radix Colors](https://www.radix-ui.com/colors) to apply palettes consistently, ensure accessibility, and seamlessly switch between light and dark mode. Icons are from [Remix Icon](https://remixicon.com). Styles are written using [vanilla-extract](https://vanilla-extract.style)—a fantastic little library which adds TypeScript's type safety to your theming and variables and then compiles down to static CSS.
+I use [Radix Colors](https://www.radix-ui.com/colors) to apply palettes consistently, ensure accessibility, and seamlessly switch between light and dark mode. Icons are from [Remix Icon](https://remixicon.com). Styles are written using [vanilla-extract](https://vanilla-extract.style)—a fantastic little library which adds TypeScript's type safety to your theming and variables and then compiles down to static CSS. I don’t use a grid; [here’s why.](https://gridless.design)
 
 ## Sounds
 

--- a/src/pages/colophon.md
+++ b/src/pages/colophon.md
@@ -28,7 +28,7 @@ Typography is scaled using a lot of math and a [fluid type scale](https://utopia
 
 Type inspiration lives everywhere—comic art, video games, bodegas—but I often return to a handful of resources:
 
-- *The Elements of Typographic Style* by Robert Bringhurst
+- [*The Elements of Typographic Style*](https://bookshop.org/a/97627/9780881792126) by Robert Bringhurst
 - [Butterick’s Practical Typography](https://practicaltypography.com)
 - Bethany Heck’s [Font Review Journal](https://fontreviewjournal.com)
 - [Fonts In Use](https://fontsinuse.com)

--- a/src/styles/base.css.ts
+++ b/src/styles/base.css.ts
@@ -20,7 +20,6 @@ globalStyle("body", {
   fontSize: tokens.fontSize.body,
   fontFamily: tokens.fontFamily.sans,
   fontFeatureSettings: '"ss02" 1', // Use opentail g
-  fontVariantNumeric: "lining-nums", // Do not use oldstyle nums
   fontVariationSettings: `'wdth' ${tokens.fontWidth.normal}, 'wght' ${theme.fontWeight.normal}`,
   lineHeight: tokens.lineHeight.body,
   textRendering: "optimizeLegibility",

--- a/src/styles/base.css.ts
+++ b/src/styles/base.css.ts
@@ -20,6 +20,7 @@ globalStyle("body", {
   fontSize: tokens.fontSize.body,
   fontFamily: tokens.fontFamily.sans,
   fontFeatureSettings: '"ss02" 1', // Use opentail g
+  fontVariantNumeric: "lining-nums", // Do not use oldstyle nums
   fontVariationSettings: `'wdth' ${tokens.fontWidth.normal}, 'wght' ${theme.fontWeight.normal}`,
   lineHeight: tokens.lineHeight.body,
   textRendering: "optimizeLegibility",
@@ -65,11 +66,6 @@ globalStyle("h6", {
   fontSize: tokens.fontSize.body,
   fontVariationSettings: `'wdth' ${tokens.fontWidth.normal}, 'wght' ${theme.fontWeight.medium}`,
   lineHeight: tokens.lineHeight.h6,
-});
-
-globalStyle("p", {
-  fontSize: tokens.fontSize.body,
-  fontFamily: tokens.fontFamily.serif,
 });
 
 globalStyle("small", {

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -34,6 +34,7 @@ export const theme = createGlobalThemeContract(
     fontWeight: {
       light: "",
       prose: "",
+      code: "",
       normal: "",
       medium: "",
       bold: "",
@@ -73,8 +74,8 @@ export const theme = createGlobalThemeContract(
 
 createGlobalTheme('[data-theme="light"]', theme, {
   background: {
-    default: plum.plum1,
-    alt: plum.plum2,
+    default: mauve.mauve1,
+    alt: mauve.mauve2,
   },
   text: {
     default: mauve.mauve12,
@@ -93,6 +94,7 @@ createGlobalTheme('[data-theme="light"]', theme, {
   fontWeight: {
     light: "300",
     prose: "360",
+    code: "420",
     normal: "420",
     medium: "480",
     bold: "700",
@@ -124,8 +126,8 @@ createGlobalTheme('[data-theme="light"]', theme, {
 
 createGlobalTheme('[data-theme="dark"]', theme, {
   background: {
-    default: plumDark.plum1,
-    alt: plumDark.plum2,
+    default: mauveDark.mauve1,
+    alt: mauveDark.mauve2,
   },
   text: {
     default: mauveDark.mauve12,
@@ -145,6 +147,7 @@ createGlobalTheme('[data-theme="dark"]', theme, {
   fontWeight: {
     light: "280",
     prose: "340",
+    code: "400",
     normal: "400",
     medium: "460",
     bold: "680",

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -25,6 +25,7 @@ export const theme = createGlobalThemeContract(
       link: "",
       linkBg: "",
       linkUnderline: "",
+      codeBg: "",
     },
     border: {
       default: "",
@@ -32,6 +33,7 @@ export const theme = createGlobalThemeContract(
     },
     fontWeight: {
       light: "",
+      prose: "",
       normal: "",
       medium: "",
       bold: "",
@@ -82,13 +84,15 @@ createGlobalTheme('[data-theme="light"]', theme, {
     link: plum.plum11,
     linkBg: plum.plum3,
     linkUnderline: mauve.mauve7,
+    codeBg: mauve.mauve3,
   },
   border: {
-    default: plum.plum4,
-    subtle: plum.plum3,
+    default: mauve.mauve7,
+    subtle: mauve.mauve6,
   },
   fontWeight: {
     light: "300",
+    prose: "360",
     normal: "420",
     medium: "480",
     bold: "700",
@@ -131,6 +135,7 @@ createGlobalTheme('[data-theme="dark"]', theme, {
     link: plumDark.plum11,
     linkBg: plumDark.plum3,
     linkUnderline: mauveDark.mauve7,
+    codeBg: mauveDark.mauve3,
   },
   border: {
     default: mauveDark.mauve7,
@@ -139,6 +144,7 @@ createGlobalTheme('[data-theme="dark"]', theme, {
   // Weights on dark background slightly lower to reduce bleed
   fontWeight: {
     light: "280",
+    prose: "340",
     normal: "400",
     medium: "460",
     bold: "680",

--- a/src/styles/tokens.css.ts
+++ b/src/styles/tokens.css.ts
@@ -41,7 +41,7 @@ export const tokens = createGlobalTheme(":root", {
     h4: "1.3",
     h5: "1.4",
     h6: "1.4",
-    body: "1.6",
+    body: "1.55",
     small: "1.5",
   },
 


### PR DESCRIPTION
- Add a list of typography inspiration to colophon
- Use text indent instead of spacing for consecutive paragraphs
- Adjust weight and color of subtitle
- Adjust weight and line-height of body text
- Add support for ordered and unordered lists
- Add support for `inline code styling`
- Adjust section spacing