### PR TITLE
feat: Show logo on sniper link button, use single line layout, add new dialogue

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -170,6 +170,7 @@ export const Icon = ({ icon, variant, size, className }: IconProps) => {
         { [styles.small]: size === "small" },
         className
       )}
+      aria-hidden="true"
     >
       {pathData}
     </svg>

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -42,20 +42,43 @@ const remarks: Record<RemarkType, Remark> = {
       "hey bestie",
       "what’s up :)",
       "EVA HERE",
+      "hey you",
       "hey nerd",
       "you found me!",
-      "welcome 2 my garden",
+      "welcome 2 my garden ✿",
+      "salutations",
+      "hi~ (❛‿❛✿̶̥̥)",
+      "oh hey",
+      "hiiieee",
+      "hello hello",
+      "hey girlie",
+      "hey dork",
+      "oh. hi",
+      "oh! you’re here",
+      "hello love ♥",
+      "bonjour",
+      "good morning(??)",
+      "hello stranger",
+      "oh? is it you?",
+      "well hello!",
+      "oi!",
+      "well, look who it is",
+      "wassup",
     ],
     emote: "neutral",
   },
   firstCharacter: {
     text: [
-      "typing! love that for you",
+      "typing! incredible",
       "we love to type",
       "tap tap tap",
       "typing is fun",
-      "typing is sexy",
       "you type so good",
+      "clicky clack",
+      "type type type",
+      "click clack",
+      "tap tap",
+      "type type",
     ],
     emote: "happy",
   },
@@ -66,9 +89,12 @@ const remarks: Record<RemarkType, Remark> = {
       "clear that box",
       "sometimes people make mistakes",
       "it’s ok to go back",
-      "i love to delete",
-      "the feminnine urge to destroy",
+      "DELETE",
+      "D E S T R O Y",
+      "the feminine urge to destroy",
       "ᕙ(`▿´)ᕗ",
+      "lol bye",
+      "yes. that can go",
     ],
     emote: "flushed",
   },
@@ -77,21 +103,25 @@ const remarks: Record<RemarkType, Remark> = {
       "nice email",
       "that’s a good email",
       "yup. that’s an email",
-      "get @ me, babyy",
-      "i love emails",
+      "what a good email",
       "mmm… electronic mail",
+      "nice address you have there",
+      "congrats! it’s an email",
+      "looks like an email",
+      "i can’t believe it’s email",
+      "email! email! email!",
     ],
     emote: "playful",
   },
   submitting: {
     text: [
-      "…",
       "taking off…",
       "subscribing…",
       "connecting wires…",
       "reticulating splines…",
       "plugging in…",
       "counting down…",
+      "dialing up…",
     ],
     emote: "thinking",
   },
@@ -99,7 +129,10 @@ const remarks: Record<RemarkType, Remark> = {
     text: [
       "yay! almost there",
       "nice! one more step",
-      "it worked! check ur inbox",
+      "almost there!",
+      "you did it! almost",
+      "get ready for e-mail (eva-mail)",
+      "good job! almost done",
     ],
     emote: "starstruck",
   },
@@ -107,10 +140,13 @@ const remarks: Record<RemarkType, Remark> = {
     text: [
       "computer says no",
       "that didn’t work",
-      "it broke, idk",
+      "it broke. idk",
       "everything fell apart",
       "try again?",
-      "ugh. computers",
+      "oh no. computers",
+      "hm.. it broke. dang",
+      "that didn’t work. hm",
+      "something went wrong",
     ],
     emote: "sob",
   },
@@ -232,23 +268,16 @@ export const SubscribeForm = () => {
     <div className={styles.form}>
       <Dialogue text={currentText} emote={currentEmote} />
       <form onSubmit={handleSubmit}>
-        {!hasSubmitted && (
+        {!hasSubmitted ? (
           <div
             className={styles.inputWrapper}
             aria-disabled={isSubmitting || hasSubmitted}
           >
-            <Icon
-              icon={isSubmitting ? "loader" : "mail"}
-              className={classNames(styles.inputIcon, {
-                [styles.loading]: isSubmitting,
-              })}
-              variant="filled"
-            />
             <input
               className={styles.input}
               type="email"
               name="email"
-              placeholder="Email"
+              placeholder="Your email"
               onFocus={handleFocus}
               onBlur={handleBlur}
               onKeyDown={handleKeyDown}
@@ -256,26 +285,33 @@ export const SubscribeForm = () => {
               value={recipientEmail}
               disabled={isSubmitting || hasSubmitted}
             />
+            <button
+              type="submit"
+              className={styles.iconButton}
+              disabled={isSubmitting || hasSubmitted}
+            >
+              <Icon
+                icon={isSubmitting ? "loader" : "arrowRight"}
+                className={classNames({
+                  [styles.loading]: isSubmitting,
+                })}
+              />
+            </button>
           </div>
-        )}
-        {hasSubmitted && sniperData ? (
-          <a href={sniperData.url} className={styles.button} target="_blank">
-            Confirm email in {sniperData.provider_pretty}
-            <Icon icon="arrowRight" className={styles.buttonIcon} />
+        ) : sniperData ? (
+          <a
+            href={sniperData.url}
+            className={styles.sniperLink}
+            target="_blank"
+          >
+            <div className={styles.sniperLogo}>
+              <img src={sniperData.image} />
+            </div>
+            Open {sniperData.provider_pretty}
+            <Icon icon="arrowRight" className={styles.arrow} />
           </a>
         ) : (
-          <button
-            type="submit"
-            className={styles.button}
-            disabled={isSubmitting || hasSubmitted}
-            key="subscribeButton"
-          >
-            {isSubmitting
-              ? "Subscribing…"
-              : hasSubmitted
-              ? "Confirm in email app"
-              : "Subscribe"}
-          </button>
+          <div className={styles.checkInbox}>Check your inbox</div>
         )}
       </form>
     </div>

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -289,6 +289,7 @@ export const SubscribeForm = () => {
               type="submit"
               className={styles.iconButton}
               disabled={isSubmitting || hasSubmitted}
+              aria-label="Subscribe"
             >
               <Icon
                 icon={isSubmitting ? "loader" : "arrowRight"}

--- a/src/components/Subscribe/subscribe.css.ts
+++ b/src/components/Subscribe/subscribe.css.ts
@@ -1,7 +1,16 @@
-import { globalKeyframes, style } from "@vanilla-extract/css";
+import { globalKeyframes, globalStyle, style } from "@vanilla-extract/css";
 
 import { theme } from "../../styles/theme.css";
 import { tokens } from "../../styles/tokens.css";
+
+globalKeyframes("spin", {
+  "0%": {
+    transform: "rotate(0deg)",
+  },
+  "100%": {
+    transform: "rotate(360deg)",
+  },
+});
 
 export const form = style({
   height: "100%",
@@ -13,29 +22,10 @@ export const form = style({
 export const inputWrapper = style({
   position: "relative",
   width: "100%",
-  marginBlockEnd: "0.5rem",
-
   selectors: {
     "&[aria-disabled=true]": {
       pointerEvents: "none",
     },
-  },
-});
-
-export const inputIcon = style({
-  color: theme.text.iconA,
-  position: "absolute",
-  marginTop: "-0.1rem",
-  top: "calc(50% - 11px)",
-  left: "0.5rem",
-});
-
-globalKeyframes("spin", {
-  "0%": {
-    transform: "rotate(0deg)",
-  },
-  "100%": {
-    transform: "rotate(360deg)",
   },
 });
 
@@ -46,11 +36,8 @@ export const loading = style({
 export const input = style({
   color: theme.text.default,
   background: theme.elementBg.default,
-  lineHeight: "1",
-  borderRadius: tokens.radius[2],
-  padding: "0.75rem 0.75rem 0.75rem 2.5rem",
-  width: "100%",
-  border: "none",
+  padding: "0 1rem",
+  paddingInlineEnd: "3rem",
   ":hover": {
     background: theme.elementBg.hover,
   },
@@ -62,19 +49,21 @@ export const input = style({
   },
 });
 
-export const button = style({
+export const iconButton = style({
   background: theme.solidBg.default,
   color: theme.color.whiteA12,
-  padding: "0.75rem",
+  position: "absolute",
+  top: "50%",
+  transform: "translateY(-50%)",
+  right: "0.5rem",
+  width: "32px",
+  height: "32px",
   borderRadius: tokens.radius[2],
-  lineHeight: "1",
-  width: "100%",
-  display: "flex",
-  flexDirection: "row",
-  alignItems: "center",
-  justifyContent: "center",
   border: "none",
   cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
   ":hover": {
     background: theme.solidBg.hover,
   },
@@ -85,9 +74,52 @@ export const button = style({
   },
 });
 
-export const buttonIcon = style({
+export const sniperLink = style({
+  background: theme.solidBg.default,
+  color: theme.color.whiteA12,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  flexDirection: "row",
+  borderRadius: tokens.radius[3],
+  padding: "0 0.5rem",
+  ":hover": {
+    background: theme.solidBg.hover,
+  },
+});
+
+export const checkInbox = style({
+  background: theme.elementBg.default,
+  color: theme.text.default,
+  textAlign: "center",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+globalStyle(`${input}, ${sniperLink}, ${checkInbox}`, {
+  height: "3rem",
+  width: "100%",
+  border: "none",
+  borderRadius: tokens.radius[3],
+  lineHeight: "1",
+});
+
+export const arrow = style({
   flexShrink: "0",
   position: "relative",
-  marginBlock: "-0.5rem",
-  marginInlineStart: "0.5rem",
+  marginInlineStart: "auto",
+  marginInlineEnd: "0.25rem",
+});
+
+export const sniperLogo = style({
+  backgroundColor: theme.color.whiteA12,
+  width: "32px",
+  height: "32px",
+  padding: "0.25rem",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  marginInlineEnd: "0.75rem",
+  borderRadius: tokens.radius[2],
 });

--- a/src/pages/subscribe/index.astro
+++ b/src/pages/subscribe/index.astro
@@ -1,24 +1,11 @@
 ---
-import Box from "src/components/Box/Box.astro";
-import Stack from "src/components/Stack/Stack.astro";
-import CenteredLayout from "src/layouts/CenteredLayout.astro";
-
-import { SubscribeForm } from "../../components/Subscribe/SubscribeForm";
+import Subscribe from "../../components/Subscribe/Subscribe.astro";
+import CenteredLayout from "../../layouts/CenteredLayout.astro";
 ---
 
 <CenteredLayout
   title="Subscribe"
   description="Occasional notes on design, text, and things outside a screen."
 >
-  <Box>
-    <Stack>
-      <h2>Notes From Eva</h2>
-      <p>
-        Occasionally, I write and share some thoughts about design, development,
-        and things outside the screen.
-      </p>
-      <SubscribeForm client:load />
-      <small>Zero tracking. I don’t want your data.</small>
-    </Stack>
-  </Box>
+  <Subscribe />
 </CenteredLayout>


### PR DESCRIPTION
- Add brand logo to the button for sniper links
- Use a condensed, single-block layout for email input and button
- Handle fallback for sniper links more effectively
- Add new dialogue options
- Update /subscribe page to use same component
- Set `Icon` component to `aria-hidden="true"`

<img width="346" alt="image" src="https://github.com/evadecker/evadecker.com/assets/4117920/1701c66f-060b-44cd-8768-c69e051f7cc7">

<img width="343" alt="image" src="https://github.com/evadecker/evadecker.com/assets/4117920/31fcd0dc-ed61-492c-8bb3-17f971ca5143">
