### PR TITLE
fix: Set button padding to zero

### DIFF
--- a/src/components/Subscribe/subscribe.css.ts
+++ b/src/components/Subscribe/subscribe.css.ts
@@ -58,6 +58,7 @@ export const iconButton = style({
   right: "0.5rem",
   width: "32px",
   height: "32px",
+  padding: "0",
   borderRadius: tokens.radius[2],
   border: "none",
   cursor: "pointer",


### PR DESCRIPTION
The icon was not appearing on iOS because of default browser padding being applied to the button. This removes default padding.

Learned how to inspect directly on iOS by connecting to the Mac! Neat!