### PR TITLE
fix: Add client:idle directive to RelativeDate in footer

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -79,7 +79,12 @@ try {
           <a class={styles.link} href="/colophon">Colophon</a>
         </Stack>
       </Grid>
-      <RelativeDate date={dateModified} prefix="Last tended" icon="sparkling" />
+      <RelativeDate
+        date={dateModified}
+        prefix="Last tended"
+        icon="sparkling"
+        client:idle
+      />
     </Stack>
   </Center>
 </footer>


### PR DESCRIPTION
- Add Astro hydration to prevent relative time errors
- Fixes #149 