### PR TITLE
fix: Improve keyboard handling for subscribe input

### DIFF
--- a/src/components/Subscribe/Subscribe.astro
+++ b/src/components/Subscribe/Subscribe.astro
@@ -12,7 +12,7 @@ import { SubscribeForm } from "./SubscribeForm";
   <Grid>
     <Cover>
       <Stack spacing="tight">
-        <header class="header">Notes From Eva</header>
+        <header class="header">Notes from Eva</header>
         <small>
           A few times a year, I share thoughts and observations about design,
           development, and life outside a screen. Subscribe to follow along. No

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -188,20 +188,21 @@ export const SubscribeForm = () => {
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setRecipientEmail(e.target.value);
+    const { value } = e.target;
+    setRecipientEmail(value);
 
-    if (isValidEmail(e.target.value)) {
+    if (isValidEmail(value)) {
       displayNewRemark("validEmail", { force: true });
     }
 
     if (
-      e.target.value.length === TRIGGER_SOME_CHARACTERS_DIALOGUE_AT_LENGTH &&
-      e.target.value.length > recipientEmail.length
+      value.length === TRIGGER_SOME_CHARACTERS_DIALOGUE_AT_LENGTH &&
+      value.length > recipientEmail.length
     ) {
       displayNewRemark("someCharacters");
     }
 
-    if (e.target.value.length < recipientEmail.length) {
+    if (value.length < recipientEmail.length) {
       displayNewRemark("deleting");
     }
   };

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -32,6 +32,7 @@ interface Remark {
   emote: EmoteType;
 }
 
+const TRIGGER_SOME_CHARACTERS_DIALOGUE_AT_LENGTH = 4;
 const REMARK_TIMEOUT = 1500;
 
 const remarks: Record<RemarkType, Remark> = {
@@ -194,7 +195,7 @@ export const SubscribeForm = () => {
     }
 
     if (
-      e.target.value.length === 4 &&
+      e.target.value.length === TRIGGER_SOME_CHARACTERS_DIALOGUE_AT_LENGTH &&
       e.target.value.length > recipientEmail.length
     ) {
       displayNewRemark("someCharacters");

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -162,9 +162,6 @@ export const SubscribeForm = () => {
     const shouldDisplayNewRemark =
       options?.force === true || !justDisplayedRemarks;
 
-    console.log("remarkType", remarkType);
-    console.log("currentRemarkType", currentRemarkType);
-
     if (shouldDisplayNewRemark && remarkType !== currentRemarkType) {
       setCurrentRemarkType(remarkType);
       setCurrentText(getRandomRemark(remarks[remarkType].text));


### PR DESCRIPTION
- Do not display an initial message on scroll (distracting, repetitive) — wait until input is focused
- Remove some dialogue options
- Add a check in `displayNewRemark()` for `remarkType !== currentRemarkType` to prevent duplicate messages from showing
- Display dialogue when `someCharacters` have been typed rather than on `firstCharacter`
- Resolves #144
- Move `handleKeyDown` logic for deletion and characters into `handleChange`; use `.length` to check for deletion in order to accommodate non-delete key removal of text such as `command`+`x`, etc.