### PR TITLE
feat: Persist Sam stickers

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -24,7 +24,7 @@ import { ToggleTheme } from "./ToggleTheme.tsx";
   <nav>
     <a class="wordmark" href="/">Eva Decker</a>
     <div class="links">
-      <button class="shoo">Shoo</button>
+      <button class="shoo" type="button">Shoo</button>
       <a href="/about">About</a>
     </div>
     <div class="toggle">

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -2,10 +2,29 @@
 import { ToggleTheme } from "./ToggleTheme.tsx";
 ---
 
+<script>
+  import { numSams, clearSams } from "../../stores/sam";
+
+  const shooButton = document.querySelector("button.shoo");
+
+  if (shooButton) {
+    shooButton.addEventListener("click", () => {
+      clearSams();
+    });
+
+    numSams.subscribe((num) => {
+      num === 0
+        ? shooButton.classList.add("hidden")
+        : shooButton.classList.remove("hidden");
+    });
+  }
+</script>
+
 <header transition:persist>
   <nav>
     <a class="wordmark" href="/">Eva Decker</a>
     <div class="links">
+      <button class="shoo">Shoo</button>
       <a href="/about">About</a>
     </div>
     <div class="toggle">
@@ -56,17 +75,23 @@ import { ToggleTheme } from "./ToggleTheme.tsx";
     margin-inline-start: auto;
   }
 
-  .links a {
+  .links a,
+  .links button {
+    background: transparent;
     padding: 0.08em 0.4em 0.03em;
+    border: none;
     border-radius: var(--radius-sm);
+    cursor: pointer;
   }
 
-  .links a:hover {
+  .links a:hover,
+  .links button:hover {
     background: var(--pink-a3);
     color: var(--pink-12);
   }
 
-  .links a:active {
+  .links a:active,
+  .links button:active {
     background: var(--pink-a4);
     color: var(--pink-12);
   }
@@ -76,5 +101,23 @@ import { ToggleTheme } from "./ToggleTheme.tsx";
     width: 40px;
     height: 40px;
     margin-inline-start: 0.5em;
+  }
+
+  .links .shoo {
+    background: var(--pink-9);
+    color: var(--white-a12);
+  }
+
+  .links .shoo:hover {
+    background: var(--pink-10);
+    color: var(--white-a12);
+  }
+
+  .links .shoo:active {
+    background: var(--pink-9);
+  }
+
+  .shoo.hidden {
+    display: none;
   }
 </style>

--- a/src/components/SamStickers/SamStickers.tsx
+++ b/src/components/SamStickers/SamStickers.tsx
@@ -1,9 +1,9 @@
 import { useStore } from "@nanostores/react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import { nanoid } from "nanoid";
 import { useEffect, useState } from "react";
 
-import { clearSams, numSams } from "../../stores/sam";
+import { numSams } from "../../stores/sam";
 import { SamSticker, type SamStickerProps } from "./SamSticker";
 
 export const SamStickers = () => {
@@ -24,12 +24,11 @@ export const SamStickers = () => {
     if ($numSams > samArray.length) {
       addSticker();
     }
-  }, [$numSams]);
 
-  const handleClear = () => {
-    setSamArray([]);
-    clearSams();
-  };
+    if ($numSams === 0) {
+      setSamArray([]);
+    }
+  }, [$numSams]);
 
   return (
     <div className="stickers">
@@ -37,23 +36,6 @@ export const SamStickers = () => {
         {samArray.map(({ id, variant }) => (
           <SamSticker key={id} id={id} variant={variant} />
         ))}
-        {$numSams >= 3 && (
-          <motion.button
-            className="shoo"
-            onClick={handleClear}
-            initial={{ opacity: 0, y: 100 }}
-            animate={{
-              opacity: 1,
-              y: 0,
-              transition: { type: "spring", bounce: 0.5 },
-            }}
-            exit={{ opacity: 0, y: 100 }}
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-          >
-            shoo!
-          </motion.button>
-        )}
       </AnimatePresence>
     </div>
   );

--- a/src/components/SamStickers/samstickers.spec.ts
+++ b/src/components/SamStickers/samstickers.spec.ts
@@ -18,7 +18,7 @@ test("displays Shoo button after 3 Sams have appeared", async ({ page }) => {
     await page.getByRole("button", { name: "Samwise" }).dispatchEvent("click");
     await expect(samStickers).toHaveCount(i + 1);
   }
-  await expect(page.getByRole("button", { name: "shoo!" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Shoo" })).toBeVisible();
 });
 
 test("shoos the Sams", async ({ page }) => {
@@ -29,7 +29,7 @@ test("shoos the Sams", async ({ page }) => {
     await expect(samStickers).toHaveCount(i + 1);
   }
 
-  await page.getByRole("button", { name: "shoo!" }).click();
+  await page.getByRole("button", { name: "Shoo" }).click();
 
   const samStickersCount = await samStickers.count();
 

--- a/src/components/SamStickers/stickers.css
+++ b/src/components/SamStickers/stickers.css
@@ -1,18 +1,3 @@
-.shoo {
-  all: unset;
-  position: fixed;
-  background: var(--mauve-12);
-  color: var(--mauve-1);
-  padding: 0.5rem 1rem;
-  border-radius: var(--radius-sm);
-  right: 2rem;
-  bottom: 2rem;
-  font-weight: var(--font-weight-bold);
-  cursor: pointer;
-  pointer-events: auto;
-  z-index: 500;
-}
-
 .sticker {
   position: absolute;
   width: 200px;
@@ -54,7 +39,7 @@
 }
 
 .stickers {
-  position: absolute;
+  position: fixed;
   inset: 0;
   pointer-events: none;
   overflow: hidden;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ import { ViewTransitions } from "astro:transitions";
 
 import Footer from "../components/Footer/Footer.astro";
 import Header from "../components/Header/Header.astro";
+import { SamStickers } from "../components/SamStickers/SamStickers";
 
 interface Props {
   title: string;
@@ -67,7 +68,7 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Eva Decker`;
     </script>
     <ViewTransitions />
   </head>
-  <body transition:animate="none" transition:persist>
+  <body transition:animate="none">
     <script is:inline src="/scripts/preloadTheme.js"></script>
     <Header />
     <main
@@ -93,6 +94,7 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Eva Decker`;
         padding-block-end: 4rem;
       }
     </style>
+    <SamStickers client:idle transition:persist />
     <slot name="after-footer" />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import { SamStickers } from "../components/SamStickers/SamStickers";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import AboutCard from "./index/AboutCard.astro";
 import HeroCard from "./index/HeroCard.astro";
@@ -28,13 +27,6 @@ import SubscribeCard from "./index/SubscribeCard.astro";
       </div>
     </div>
   </div>
-  <SamStickers client:visible slot="after-footer" />
-
-  <script>
-    import { addSam } from "../stores/sam";
-    const samButton = document.querySelector("[data-sam-button]");
-    samButton?.addEventListener("click", () => addSam());
-  </script>
 </BaseLayout>
 
 <style>

--- a/src/pages/index/AboutCard.astro
+++ b/src/pages/index/AboutCard.astro
@@ -23,6 +23,14 @@ import { Icon } from "../../components/Icon/Icon";
   </div>
 </Box>
 
+<script>
+  import { addSam } from "../../stores/sam";
+  document.addEventListener("astro:page-load", () => {
+    const samButton = document.querySelector("[data-sam-button]");
+    samButton?.addEventListener("click", () => addSam());
+  });
+</script>
+
 <style>
   @keyframes arrowClip {
     0% {


### PR DESCRIPTION
- Persist Sam stickers across pages
- Make the stickers canvas `position: fixed` to avoid page height oddness when moving between pages, and ensure that stickers are always visible when added to a random coordinate
- Move "Shoo" button to the header, rendered conditionally
- Resolves #181 