### PR TITLE
fix: Remove iOS gray highlight, update dark mode synth key colors

### DIFF
--- a/src/components/Postcard/Dialogue/dialogue.css
+++ b/src/components/Postcard/Dialogue/dialogue.css
@@ -45,6 +45,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
 }
 
 .stamp:active {

--- a/src/components/Synth/Synth.astro
+++ b/src/components/Synth/Synth.astro
@@ -592,9 +592,9 @@ import SynthScreen from "./SynthScreen.astro";
 
     :global(.dark) & {
       --synth-whitekey: var(--jade-12);
-      --synth-whitekey-pressed: var(--jade-12);
+      --synth-whitekey-pressed: white;
       --synth-blackkey: var(--jade-3);
-      --synth-blackkey-pressed: var(--jade-2);
+      --synth-blackkey-pressed: var(--jade-1);
       --synth-stroke: var(--jade-1);
       --synth-lcd-bg: var(--jade-12);
       --synth-lcd-light: white;


### PR DESCRIPTION
- No gray rectangles!
- Increase contrast for colors on pressed synth key state in dark mode