### PR TITLE
fix: Use `www` for Cityblock link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,8 +19,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <p>
         I'm a designer and developer based in Brooklyn, NY. Past gigs include
         product design and UX engineering at
-        <a href="https://dropbox.com">Dropbox</a>, <a
-          href="https://cityblock.com">Cityblock</a
+        <a href="https://www.dropbox.com">Dropbox</a>, <a
+          href="https://www.cityblock.com">Cityblock</a
         >, and <a href="https://swiftype.com">Swiftype</a>. I'm currently <strong
           >open to work</strong
         >.


### PR DESCRIPTION
- URL without `www` would not resolve successfully
- Also add `www` to Dropbox link since it redirects there
- No `www` for Swiftype link because it strips it