### PR TITLE
fix: ESLint parser for `.astro` files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,11 +29,7 @@
   "overrides": [
     {
       "files": ["*.astro"],
-      "parser": "astro-eslint-parser",
-      "parserOptions": {
-        "parser": "@typescript-eslint/parser",
-        "extraFileExtensions": [".astro"]
-      }
+      "parser": "astro-eslint-parser"
     }
   ]
 }


### PR DESCRIPTION
Fix ESLint parsing (?)